### PR TITLE
Serialize cell state in annotation file

### DIFF
--- a/notebooks/A_CNN_Annotation_with_Napari.ipynb
+++ b/notebooks/A_CNN_Annotation_with_Napari.ipynb
@@ -293,7 +293,7 @@
     "        export_data['labels'] = points_layer.properties['State'].tolist()\n",
     "        \n",
     "        # serialize the CellState labels\n",
-    "        export_data['cell_states'] = {s.name: s.value for s in CellState}\n",
+    "        export_data['states'] = {s.name: s.value for s in CellState}\n",
     "        \n",
     "        # extract the image patches here\n",
     "        with ZipFile(f\"../data/{SESSION_NAME}.zip\", 'w') as myzip:\n",

--- a/notebooks/A_CNN_Annotation_with_Napari.ipynb
+++ b/notebooks/A_CNN_Annotation_with_Napari.ipynb
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,17 +106,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "../data/MDCK_H2B_GFP_movie.tif\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "filename = \"../data/MDCK_H2B_GFP_movie.tif\"\n",
     "print (filename)\n"
@@ -131,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,6 +291,9 @@
     "        \n",
     "        # record the state labels of the annotations \n",
     "        export_data['labels'] = points_layer.properties['State'].tolist()\n",
+    "        \n",
+    "        # serialize the CellState labels\n",
+    "        export_data['cell_states'] = {s.name: s.value for s in CellState}\n",
     "        \n",
     "        # extract the image patches here\n",
     "        with ZipFile(f\"../data/{SESSION_NAME}.zip\", 'w') as myzip:\n",
@@ -357,18 +352,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "JSON file & image patches have been exported.\n",
-      "'../data/annotation_02-17-2021--14-18-42.zip'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with napari.gui_qt():\n",
     "    \n",
@@ -418,7 +404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This serializes the `CellState` enum in the annotation file, so that it can be used in other notebooks without having to be hard coded.