### PR TITLE
Fix test images variable for image patch projection

### DIFF
--- a/notebooks/D_CNN_Inference_and_Embedding.ipynb
+++ b/notebooks/D_CNN_Inference_and_Embedding.ipynb
@@ -22,7 +22,11 @@
     "\n",
     "1. Execute the first cell containing code below, which will install the CellX library & create a local test directory in the environment of the virtual machine. The executed first cell will print ```Building wheel for cellx (setup.py) ... done```. (Note: This virtual environment is different from the one created for the Training notebook, which is why we need to re-install the external `cellx` library etc.)\n",
     "\n",
-    "2. Click on the ``` 📁``` folder icon located on the left-side dashboard of the Colab notebook. Drag your annotated zip file(s) into the \"test\" folder and your saved model (the `.h5` file) into the \"content\" folder - the parent folder of the \"test\" folder.\n",
+<<<<<<< HEAD
+    "2. Click on the ``` 📁``` folder icon located on the left-side dashboard of the Colab notebook. Drag your saved model (the `.h5` file) into the `/content/` folder and your annotated zip file(s) into the `/content/test/` folder.\n",
+=======
+    "2. Click on the ``` 📁``` folder icon located on the left-side dashboard of the Colab notebook, this is the default `content` directory where you can see the following subdirectories: `sample_data` (default) & `test`. Drag your saved model (the `.h5` file) into the `content` folder and your annotated zip file(s) into the `test` folder.\n",
+>>>>>>> fix #34 & minor markdown edits
     "\n",
     "3. You can now now run the entire notebook by clicking on ```Runtime``` > ```Run``` in the upper main dashboard. \n",
     "\n",
@@ -124,7 +128,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Import Testing Dataset from the zip files:"
+    "### Import test dataset from the zip files:"
    ]
   },
   {
@@ -140,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load the Model"
+    "### Load the Model:"
    ]
   },
   {
@@ -173,7 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Normalize the images in the test dataset"
+    "### Normalize the images in the test dataset:"
    ]
   },
   {
@@ -208,7 +212,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Run the Model on the Testing Set"
+    "## Run the Model on the test images:"
    ]
   },
   {
@@ -240,7 +244,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Predictions on Testing Images"
+    "### Show predictions on the test images:"
    ]
   },
   {
@@ -285,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Evaluation Metrics"
+    "### Calculate evaluation metrics:"
    ]
   },
   {
@@ -328,7 +332,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Dimensionality reduction with UMAP"
+    "### Dimensionality reduction with UMAP:"
    ]
   },
   {
@@ -337,7 +341,7 @@
    "source": [
     "By running the below cell, we see that the model output is an array of 2 dimensions: \n",
     "* the 1st dimension corresponds to the number of test images used \n",
-    "* the 2nd dimension corresponds to the number of possible classes predefined in our model"
+    "* the 2nd dimension corresponds to the number of possible classes pre-defined in our model"
    ]
   },
   {
@@ -415,7 +419,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Image patch projection"
+    "### 2D image patch projection of model embedding:"
    ]
   },
   {
@@ -433,7 +437,7 @@
    "source": [
     "# convert single-channel test images to rgb three-channel images\n",
     "print(f\"shape of test images: {test_images_array.shape}\")\n",
-    "rgb_images = np.concatenate([test_images]*3, axis=-1)\n",
+    "rgb_images = np.concatenate([test_images_array]*3, axis=-1)\n",
     "print(f\"shape of rgb test images: {rgb_images.shape}\")\n",
     "# normalise image values to 0-1 range (Min-Max scaling) & convert to 8-bit\n",
     "rgb_images = ((rgb_images-np.min(rgb_images))/(np.ptp(rgb_images)) * 255).astype(np.uint8)"
@@ -443,7 +447,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create the grid of image patches corresponding to the UMAP embedding. (This is basically a 2D histogram where points on a same grid cell are binned and the average of the binned images is projected.)"
+    "Create the grid of image patches corresponding to the UMAP embedding. This is basically a 2D histogram where points on a same grid cell are binned and the average of the corresponding images is calculated before being overlaid."
    ]
   },
   {
@@ -460,7 +464,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a figure to show the image projection. The last line allows you to save the projection to the Colab \"content\" folder, but remember to then go on the \"...\" button next to the file generated in the Files tab (click the Refresh button if you don't see it) in order to download a local copy of the file. Reminder: Files saved during a Colab session will be lost upon closing this session!"
+    "Create a figure to show the image projection. \n",
+<<<<<<< HEAD
+    "The last line allows you to save the projection as `.png` file to the Colab `/content/` folder, but remember to then go on the \"...\" button next to the file generated in the Files tab (click the Refresh button if you don't see it) in order to download the file.\n",
+=======
+    "You can uncomment the last line if you want to save the projection as `.png` file, it will appear in the Files tab (if you don't see it, press the middle Refresh button at the top of the tab). \n",
+    "Remember to then go on the \"...\" button to the right of the `.png` file to download it.\n",
+>>>>>>> fix #34 & minor markdown edits
+    "Reminder: Files saved during a Colab session will be lost upon closing this session!"
    ]
   },
   {
@@ -500,7 +511,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/D_CNN_Inference_and_Embedding.ipynb
+++ b/notebooks/D_CNN_Inference_and_Embedding.ipynb
@@ -22,11 +22,7 @@
     "\n",
     "1. Execute the first cell containing code below, which will install the CellX library & create a local test directory in the environment of the virtual machine. The executed first cell will print ```Building wheel for cellx (setup.py) ... done```. (Note: This virtual environment is different from the one created for the Training notebook, which is why we need to re-install the external `cellx` library etc.)\n",
     "\n",
-<<<<<<< HEAD
-    "2. Click on the ``` 📁``` folder icon located on the left-side dashboard of the Colab notebook. Drag your saved model (the `.h5` file) into the `/content/` folder and your annotated zip file(s) into the `/content/test/` folder.\n",
-=======
     "2. Click on the ``` 📁``` folder icon located on the left-side dashboard of the Colab notebook, this is the default `content` directory where you can see the following subdirectories: `sample_data` (default) & `test`. Drag your saved model (the `.h5` file) into the `content` folder and your annotated zip file(s) into the `test` folder.\n",
->>>>>>> fix #34 & minor markdown edits
     "\n",
     "3. You can now now run the entire notebook by clicking on ```Runtime``` > ```Run``` in the upper main dashboard. \n",
     "\n",
@@ -465,12 +461,8 @@
    "metadata": {},
    "source": [
     "Create a figure to show the image projection. \n",
-<<<<<<< HEAD
-    "The last line allows you to save the projection as `.png` file to the Colab `/content/` folder, but remember to then go on the \"...\" button next to the file generated in the Files tab (click the Refresh button if you don't see it) in order to download the file.\n",
-=======
     "You can uncomment the last line if you want to save the projection as `.png` file, it will appear in the Files tab (if you don't see it, press the middle Refresh button at the top of the tab). \n",
     "Remember to then go on the \"...\" button to the right of the `.png` file to download it.\n",
->>>>>>> fix #34 & minor markdown edits
     "Reminder: Files saved during a Colab session will be lost upon closing this session!"
    ]
   },


### PR DESCRIPTION
- Fix #34: `rgb_images` was created from `test_images` instead of `test_images_array`, which resulted in incorrect dimensions for the projection.

- Minor changes to markdown for consistency