### PR TITLE
(Notebook D) Replace hardcoded labels with labels returned by `read_annotations` function

### DIFF
--- a/notebooks/D_CNN_Inference_and_Embedding.ipynb
+++ b/notebooks/D_CNN_Inference_and_Embedding.ipynb
@@ -107,7 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Define paths & class labels:"
+    "### Define path:"
    ]
   },
   {
@@ -123,7 +123,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Import test dataset from the zip files:"
+    "### Import test dataset from the zip files & define class labels:"
    ]
   },
   {
@@ -132,7 +132,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_images, test_labels, states = read_annotations(TEST_PATH)"
+    "test_images, test_labels, states = read_annotations(TEST_PATH)\n",
+    "LABELS = list(states)"
    ]
   },
   {
@@ -185,8 +186,8 @@
     "def normalize_image_array(img):\n",
     "    img_mean = np.mean(img)\n",
     "    img_stddev = max(np.std(img), 1.0/np.size(img))\n",
-    "    img = np.subtract(img,img_mean)\n",
-    "    img = np.divide(img,img_stddev)\n",
+    "    img = np.subtract(img, img_mean)\n",
+    "    img = np.divide(img, img_stddev)\n",
     "    # clip to 4 standard deviations\n",
     "    img = np.clip(img, -4, 4)\n",
     "    return img"
@@ -199,7 +200,8 @@
    "outputs": [],
    "source": [
     "test_images = [normalize_image_array(image) for image in test_images]\n",
-    "test_images_array = np.array(test_images)[...,np.newaxis] # convert to numpy array for model prediction\n",
+    "# convert to numpy array for model prediction\n",
+    "test_images_array = np.array(test_images)[..., np.newaxis] \n",
     "test_labels_array = np.array(test_labels)"
    ]
   },
@@ -232,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_predictions = softmax(test_predictions,axis=1)"
+    "test_predictions = softmax(test_predictions, axis=1)"
    ]
   },
   {
@@ -259,15 +261,15 @@
     "    num_examples, # number of testing examples to show\n",
     "    test_images\n",
     "):\n",
-    "    plt.figure(figsize=(10,3*(int(num_examples/5)+1)))\n",
-    "    plt.suptitle('Predictions',fontsize=25,x=0.5,y=0.95)\n",
-    "    for image_num in range(min(np.shape(test_images_array)[0],num_examples)-1):\n",
-    "        plt.subplot(int(num_examples/5)+1,5,image_num+1)\n",
-    "        plt.imshow(test_images_array[image_num,:,:,0])\n",
-    "        plt.title('Image {}'.format(image_num+1))\n",
+    "    plt.figure(figsize=(10, 3*(int(num_examples/5)+1)))\n",
+    "    plt.suptitle('Predictions', fontsize=25, x=0.5, y=0.95)\n",
+    "    for image_num in range(min(np.shape(test_images_array)[0], num_examples)-1):\n",
+    "        plt.subplot(int(num_examples/5)+1, 5, image_num+1)\n",
+    "        plt.imshow(test_images_array[image_num, :, :, 0])\n",
+    "        plt.title(f'Image {image_num+1}')\n",
     "        plt.yticks([])\n",
     "        plt.xticks([])\n",
-    "        plt.xlabel(list(states)[np.argmax(test_predictions[image_num])])\n",
+    "        plt.xlabel(LABELS[np.argmax(test_predictions[image_num])])\n",
     "    plt.show()"
    ]
   },
@@ -277,7 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_testing_predictions(20,test_images)"
+    "show_testing_predictions(20, test_images)"
    ]
   },
   {
@@ -308,19 +310,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loss,accuracy = model.evaluate(test_images_array, test_labels_array)\n",
+    "loss, accuracy = model.evaluate(test_images_array, test_labels_array)\n",
     "\n",
-    "test_confusion_matrix = confusion_matrix(test_labels,np.argmax(test_predictions,axis=1))\n",
-    "test_confusion_matrix_plot = plot_confusion_matrix(test_confusion_matrix,list(states))\n",
+    "test_confusion_matrix = confusion_matrix(test_labels, np.argmax(test_predictions, axis=1))\n",
+    "test_confusion_matrix_plot = plot_confusion_matrix(test_confusion_matrix, LABELS)\n",
     "test_confusion_matrix_plot.show()\n",
     "\n",
-    "print('Testing Accuracy = ',accuracy)\n",
-    "print('Testing Loss = ',loss)\n",
+    "print(f'Testing Accuracy = {accuracy}')\n",
+    "print(f'Testing Loss = {loss}')\n",
     "\n",
-    "precision,recall,fscore,support = precision_recall_fscore_support(test_labels,np.argmax(test_predictions,axis=1))\n",
-    "print('Testing Precision = ',precision)\n",
-    "print('Testing Recall = ',recall)\n",
-    "print('Testing F1 Score = ',fscore)"
+    "precision, recall, fscore, support = precision_recall_fscore_support(\n",
+    "    test_labels,\n",
+    "    np.argmax(test_predictions, axis=1)\n",
+    ")\n",
+    "print(f'Testing Precision = {precision}')\n",
+    "print(f'Testing Recall = {recall}')\n",
+    "print(f'Testing F1 Score = {fscore}')"
    ]
   },
   {

--- a/notebooks/D_CNN_Inference_and_Embedding.ipynb
+++ b/notebooks/D_CNN_Inference_and_Embedding.ipynb
@@ -116,8 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TEST_PATH = \"./test\"\n",
-    "LABELS = [\"Interphase\", \"Prometaphase\", \"Metaphase\", \"Anaphase\", \"Apoptosis\"]"
+    "TEST_PATH = \"./test\""
    ]
   },
   {
@@ -268,7 +267,7 @@
     "        plt.title('Image {}'.format(image_num+1))\n",
     "        plt.yticks([])\n",
     "        plt.xticks([])\n",
-    "        plt.xlabel(LABELS[np.argmax(test_predictions[image_num])])\n",
+    "        plt.xlabel(list(states)[np.argmax(test_predictions[image_num])])\n",
     "    plt.show()"
    ]
   },
@@ -312,7 +311,7 @@
     "loss,accuracy = model.evaluate(test_images_array, test_labels_array)\n",
     "\n",
     "test_confusion_matrix = confusion_matrix(test_labels,np.argmax(test_predictions,axis=1))\n",
-    "test_confusion_matrix_plot = plot_confusion_matrix(test_confusion_matrix,LABELS)\n",
+    "test_confusion_matrix_plot = plot_confusion_matrix(test_confusion_matrix,list(states))\n",
     "test_confusion_matrix_plot.show()\n",
     "\n",
     "print('Testing Accuracy = ',accuracy)\n",


### PR DESCRIPTION
Fix #39: assign labels returned by `read_annotations` function to `LABELS` constant

- minor code reformatting for better readability
- replace strings with f-strings for consistency