### PR TITLE
(Notebook D) Add umap pip install

### DIFF
--- a/notebooks/D_CNN_Inference_and_Embedding.ipynb
+++ b/notebooks/D_CNN_Inference_and_Embedding.ipynb
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Install the CellX library & create subdirectories in the virtual machine:"
+    "### Install necessary packages & create subdirectories in the virtual machine:"
    ]
   },
   {
@@ -46,9 +46,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# if using colab, install cellx library and make log and data folders\n",
+    "# if using colab, install missing packages and make data folder\n",
     "\n",
     "if 'google.colab' in str(get_ipython()):\n",
+    "    !pip install umap-learn\n",
     "    !pip install -q git+git://github.com/quantumjot/cellx.git\n",
     "    !mkdir test"
    ]
@@ -507,7 +508,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix #42 

Due to `umap-learn`missing from Colab's default packages, added a `!pip install` for it before import statements.